### PR TITLE
Use FlowExecutionContext to get provided meta-property for K8S namespace

### DIFF
--- a/src/main/resources/META-INF/plugin.yml
+++ b/src/main/resources/META-INF/plugin.yml
@@ -8,7 +8,7 @@ component_descriptors:
   - bean_name: kubernetes-modifier
     name: Kubernetes modifier.
     description: >
-      Topology modifier that transform a generic topology into a Kubernetes topology.
+      Topology modifier (with namespace support) that transform a generic topology into a Kubernetes topology.
       Insert this modifier to post-location-match phase. Note that you MUST also insert the kubernetes-final-modifier to your location.
   - bean_name: kubernetes-anti-affinity-modifier
     name: Kubernetes modifier for anti-affinity policy.


### PR DESCRIPTION
# Pull Request description
The goal is to allow users to provide the namespace for k8s resources creation. 

The mean is to define a meta-property for the namespace specification, and set its value before application deployment with the namespace's **Name**.

## Description of the change

### What I did
I used the kubernetes-modifier's execution context to get the value of the meta-property defined for the namespace specification.

### How I did it
I defined a method that allows to set the value of the meta-property, if its defined, as a metadata property value of the abstract NodeTemplates generated for the k8s resources to be created (AbstractDeployment, AbstractService).

### Limitations
Currently, if one meta-property is defined, we use its **Value** as we assume its the _good_ one. If several meta-properties are defined, we use the value of the first one.

To remove this limitation, the method must be able to verify that a meta-property is one that specifies a k8s namespace, based on its ID (get from Alien its **Name** and possibly use a name definition rule (or policy) to determine if its a _good_ one.