### PR TITLE
Feature/jobs

### DIFF
--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubeTopologyUtils.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubeTopologyUtils.java
@@ -38,24 +38,29 @@ public class KubeTopologyUtils {
     // A4C & normatives types
     public static final String A4C_TYPES_CONTAINER_RUNTIME = "org.alien4cloud.extended.container.types.ContainerRuntime";
     public static final String A4C_TYPES_CONTAINER_DEPLOYMENT_UNIT = "org.alien4cloud.extended.container.types.ContainerDeploymentUnit";
+    public static final String A4C_TYPES_CONTAINER_JOB_UNIT = "org.alien4cloud.extended.container.types.ContainerJobUnit";
     public static final String A4C_TYPES_APPLICATION_DOCKER_CONTAINER = "tosca.nodes.Container.Application.DockerContainer";
     public static final String A4C_TYPES_DOCKER_VOLUME = "org.alien4cloud.nodes.DockerExtVolume";
     // K8S abstract types
     public static final String K8S_TYPES_ABSTRACT_CONTAINER = "org.alien4cloud.kubernetes.api.types.AbstractContainer";
     public static final String K8S_TYPES_ABSTRACT_DEPLOYMENT = "org.alien4cloud.kubernetes.api.types.AbstractDeployment";
+    public static final String K8S_TYPES_ABSTRACT_JOB = "org.alien4cloud.kubernetes.api.types.AbstractJob";
     public static final String K8S_TYPES_ABSTRACT_SERVICE = "org.alien4cloud.kubernetes.api.types.AbstractService";
     public static final String K8S_TYPES_ABSTRACT_VOLUME_BASE = "org.alien4cloud.kubernetes.api.types.volume.AbstractVolumeBase";
     public static final String K8S_TYPES_VOLUME_BASE = "org.alien4cloud.kubernetes.api.types.volume.VolumeBase";
     // K8S concrete types
     public static final String K8S_TYPES_CONTAINER = "org.alien4cloud.kubernetes.api.types.Container";
     public static final String K8S_TYPES_DEPLOYMENT = "org.alien4cloud.kubernetes.api.types.Deployment";
+    public static final String K8S_TYPES_JOB = "org.alien4cloud.kubernetes.api.types.Job";
     public static final String K8S_TYPES_SERVICE = "org.alien4cloud.kubernetes.api.types.Service";
     // K8S volume types
     public static final String K8S_TYPES_VOLUMES_CLAIM = "org.alien4cloud.kubernetes.api.types.volume.PersistentVolumeClaimSource";
     public static final String K8S_TYPES_VOLUMES_CLAIM_SC = "org.alien4cloud.kubernetes.api.types.volume.PersistentVolumeClaimStorageClassSource";
     // K8S resource types
     public static final String K8S_TYPES_DEPLOYMENT_RESOURCE = "org.alien4cloud.kubernetes.api.types.DeploymentResource";
-    public static final String K8S_TYPES_RESOURCE = "org.alien4cloud.kubernetes.api.types.BaseResource";
+    public static final String K8S_TYPES_JOB_RESOURCE = "org.alien4cloud.kubernetes.api.types.JobResource";
+    public static final String K8S_TYPES_BASE_JOB_RESOURCE = "org.alien4cloud.kubernetes.api.types.BaseJobResource";
+    public static final String K8S_TYPES_BASE_RESOURCE = "org.alien4cloud.kubernetes.api.types.BaseResource";
     public static final String K8S_TYPES_SERVICE_RESOURCE = "org.alien4cloud.kubernetes.api.types.ServiceResource";
     public static final String K8S_TYPES_SIMPLE_RESOURCE = "org.alien4cloud.kubernetes.api.types.SimpleResource";
     public static final String K8S_TYPES_ENDPOINT_RESOURCE = "org.alien4cloud.kubernetes.api.types.EndpointResource";

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
@@ -133,6 +133,7 @@ public class KubernetesFinalTopologyModifier extends AbstractKubernetesModifier 
         // TODO then find a way to delete servicesNodes and deloymentNodes as they are not used
         serviceNodes.forEach(nodeTemplate -> removeNode(topology, nodeTemplate));
         deploymentNodes.forEach(nodeTemplate -> removeNode(topology, nodeTemplate));
+        jobNodes.forEach(nodeTemplate -> removeNode(topology, nodeTemplate));
         Set<NodeTemplate> volumes = TopologyNavigationUtil.getNodesOfType(topology, K8S_TYPES_VOLUME_BASE, true);
         volumes.forEach(nodeTemplate -> removeNode(topology, nodeTemplate));
         Set<NodeTemplate> containers = TopologyNavigationUtil.getNodesOfType(topology, A4C_TYPES_APPLICATION_DOCKER_CONTAINER, true, false);

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
@@ -172,8 +172,12 @@ public class KubernetesFinalTopologyModifier extends AbstractKubernetesModifier 
             context.getLog().info("All resources will be created into the namespace <" + providedNamespace + ">");
         }
         // finally set the 'resource_spec' property with the JSON content of the resource specification
-        // Different resource types, but not job resources
         Set<NodeTemplate> resourceNodes = TopologyNavigationUtil.getNodesOfType(topology, K8S_TYPES_BASE_RESOURCE, true);
+        // also treat job resources
+        Set<NodeTemplate> jobResourceNodes = TopologyNavigationUtil.getNodesOfType(topology, K8S_TYPES_BASE_JOB_RESOURCE, true);
+        for (NodeTemplate jobResourceNode : jobResourceNodes) {
+            resourceNodes.add(jobResourceNode);
+        }
         for (NodeTemplate resourceNode : resourceNodes) {
             Map<String, AbstractPropertyValue> resourceNodeProperties = resourceNodeYamlStructures.get(resourceNode.getName());
             if (resourceNodeProperties != null && resourceNodeProperties.containsKey("resource_def")) {

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesLocationTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesLocationTopologyModifier.java
@@ -56,8 +56,8 @@ import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.getVa
 import static org.alien4cloud.tosca.utils.ToscaTypeUtils.isOfType;
 
 /**
- * Transform an abstract topology containing <code>DockerContainer</code>s, <code>ContainerRuntime</code>s and <code>ContainerDeploymentUnit</code>s to an
- * abstract K8S topology.
+ * Transform an abstract topology containing <code>DockerContainer</code>s, <code>ContainerRuntime</code>s and <code>ContainerDeploymentUnit</code>,
+ * or <code>ContainerJobUnit</code>, to an abstract K8S topology.
  *
  * This modifier:
  * </p>
@@ -66,6 +66,8 @@ import static org.alien4cloud.tosca.utils.ToscaTypeUtils.isOfType;
  * <code>org.alien4cloud.kubernetes.api.types.AbstractContainer</code> and fill k8s properties.</li>
  * <li>Replace all occurences of <code>org.alien4cloud.extended.container.types.ContainerDeploymentUnit</code> by
  * <code>org.alien4cloud.kubernetes.api.types.AbstractDeployment</code> and fill k8s properties.</li>
+ * <li>Replace all occurences of <code>org.alien4cloud.extended.container.types.ContainerJobUnit</code> by
+ * <code>org.alien4cloud.kubernetes.api.types.AbstractJob</code> and fill k8s properties.</li>
  * <li>Wrap all orphan <code>org.alien4cloud.kubernetes.api.types.AbstractContainer</code> inside a
  * <code>org.alien4cloud.kubernetes.api.types.AbstractDeployment</code>.</li>
  * <li>For each container endpoint, create a node of type <code>org.alien4cloud.kubernetes.api.types.AbstractService</code> that depends on the coresponding
@@ -106,12 +108,10 @@ public class KubernetesLocationTopologyModifier extends AbstractKubernetesModifi
         containerRuntimeNodes.forEach(nodeTemplate -> transformContainerRuntime(csar, topology, nodeTemplate));
 
         // replace all ContainerDeploymentUnit by org.alien4cloud.kubernetes.api.types.AbstractDeployment
-        System.out.println(">>>>>>>>>>> Replace ContainerDeploymentUnit by AbstractDeployment");
         Set<NodeTemplate> containerDeploymentUnitNodes = TopologyNavigationUtil.getNodesOfType(topology, A4C_TYPES_CONTAINER_DEPLOYMENT_UNIT, false);
         containerDeploymentUnitNodes.forEach(nodeTemplate -> transformContainerDeploymentUnit(csar, topology, nodeTemplate));
 
         // replace all ContainerJobUnit by org.alien4cloud.kubernetes.api.types.AbstractJob
-        System.out.println(">>>>>>>>>>> Replace ContainerJobUnit by AbstractJob");
         Set<NodeTemplate> containerJobUnitNodes = TopologyNavigationUtil.getNodesOfType(topology, A4C_TYPES_CONTAINER_JOB_UNIT, false);
         containerJobUnitNodes.forEach(nodeTemplate -> transformContainerJobUnit(csar, topology, nodeTemplate));
 

--- a/src/main/resources/csar/scripts/kubectl_job_run.sh
+++ b/src/main/resources/csar/scripts/kubectl_job_run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# configuration
+KUBE_ADMIN_CONFIG_PATH=/etc/kubernetes/admin.conf
+
+function create_resource(){
+    DEPLOYMENT_TMP_FILE=$(mktemp)
+
+    # create resource deployment definition
+    echo "${KUBE_RESOURCE_JOB_CONFIG}" > "${JOB_TMP_FILE}"
+
+    # deploy
+    export KUBE_JOB_ID=$(kubectl --kubeconfig "${KUBE_ADMIN_CONFIG_PATH}" create -f "${JOB_TMP_FILE}" | sed -r 's/job "([a-zA-Z0-9\-]*)" created/\1/')
+    export JOB_STATUS=$?
+
+    # cleanup
+    rm "${JOB_TMP_FILE}"
+
+    exit_if_error
+
+    command="kubectl --kubeconfig "${KUBE_ADMIN_CONFIG_PATH}" get job ${KUBE_JOB_ID} -o=jsonpath={.status.conditions[*].status}"
+
+    #wait_until_done_or_exit "$command" 60
+}
+
+create_resource

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -11,7 +11,7 @@ description: |
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.0.0
+  - docker-types:2.1.0-SNAPSHOT
   - alien-base-types:2.0.0
 
 data_types:

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -235,6 +235,38 @@ data_types:
         description: |
           The deployment strategy to use to replace existing pods with new ones.
 
+  # in version 1.10 there is another property : backoffLimit (integer) that specifies the number of retries before making this job failed (set to 6 by default)
+  org.alien4cloud.kubernetes.api.datatypes.JobSpec:
+    derived_from: org.alien4cloud.kubernetes.api.datatypes.ControllerSpec
+    description: >
+      c.f. https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#jobspec-v1-batch
+    properties:
+      activeDeadlineSeconds:
+        type: integer
+        required: false
+        description: |
+          Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
+      completions:
+        type: integer
+        required: false
+        description: |
+          Completions specifies the desired number of successfully finished pods the job should be run with.
+      manualSelector:
+        type: boolean
+        required: false
+        description: |
+          ManualSelector controls generation of pod labels and pod selectors. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.
+      parallelism:
+        type: integer
+        required: false
+        description: |
+          Parallelism specifies the maximum desired number of pods the job should run at any given time.
+      selector:
+        type: string # datetype: org.alien4cloud.kubernetes.api.datatypes.LabelSelector
+        required: false
+        description: |
+          Label query over pods that should match the pod count. Normally, the system sets this field for you
+          
   org.alien4cloud.kubernetes.api.datatypes.PodTemplateSpec:
     derived_from: tosca.datatypes.Root
     description: >

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -1244,6 +1244,28 @@ node_types:
               type: integer
           implementation: scripts/kubectl_deployment_scale.sh
 
+  org.alien4cloud.kubernetes.api.types.BaseJobResource:
+    abstract: true
+    derived_from: org.alien4cloud.nodes.Job
+    description: >
+      Represent a Job kubernetes final resource after node matching
+    properties:
+      resource_spec:
+        type: string
+        description: |
+          The the JSON serialization (and eventually transformation) of initial node properties.
+          This JSON can be used to instanciate the resource on the K8S cluster.
+
+  org.alien4cloud.kubernetes.api.types.JobResource:
+    derived_from: org.alien4cloud.kubernetes.api.types.BaseJobResource
+    interfaces:
+      tosca.interfaces.node.lifecycle.Runnable:
+        run:
+          inputs:
+            KUBE_RESOURCE_JOB_CONFIG: { get_property: [SELF, resource_spec] }
+          implementation: scripts/kubectl_job_run.sh
+          description: Standard lifecycle run operation.
+
   org.alien4cloud.kubernetes.api.types.EndpointResource:
     derived_from: org.alien4cloud.kubernetes.api.types.BaseResource
     properties:

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -1080,6 +1080,17 @@ node_types:
       spec:
         type: org.alien4cloud.kubernetes.api.datatypes.ServiceSpec
 
+  # Could define an AbstractCrontroller type, super-type for AbstractDeployment and for AbstractJob
+  # [This could allow to choose between Job and Deployment when matching ContainerDeploymentUnit]
+  # org.alien4cloud.kubernetes.api.types.AbstractDeployment:
+  #  abstract: true
+  #  derived_from: org.alien4cloud.kubernetes.api.types.Base
+  # could define spec property here, type could be org.alien4cloud.kubernetes.api.datatypes.ControllerSpec
+  #  properties:
+  #    spec:
+  #      type: org.alien4cloud.kubernetes.api.datatypes.ControllerSpec
+  # in this case don't need to define spec property in AbstractDeployment and AbstractJobe
+
   org.alien4cloud.kubernetes.api.types.Deployment:
     derived_from: org.alien4cloud.kubernetes.api.types.AbstractDeployment
 
@@ -1106,6 +1117,7 @@ node_types:
         default: Deployment
         constraints:
           - equal: Deployment
+      # Could remove this if we derive AbstractDeployment from AbstractController
       spec:
         type: org.alien4cloud.kubernetes.api.datatypes.DeploymentSpec
 
@@ -1134,6 +1146,7 @@ node_types:
         default: Job
         constraints:
           - equal: Job
+      # Could remove this if we derive AbstractJob from AbstractController
       spec:
         type: org.alien4cloud.kubernetes.api.datatypes.JobSpec
 

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -82,6 +82,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.EndpointSubsets:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#endpointsubset-v1-core
     properties:
       addresses:
         type: list
@@ -100,6 +102,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.Port:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#endpointport-v1-core
     properties:
 #      name:
 #        type: string
@@ -305,6 +309,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.PodSpec:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. hhttps://kubernetes.io/docs/api-reference/v1.6/#podtspec-v1-core
     properties:
       activeDeadlineSeconds:
         type: integer
@@ -417,6 +423,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.ContainerPort:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. hhttps://kubernetes.io/docs/api-reference/v1.6/#containerport-v1-core
     properties:
       containerPort:
         type: integer
@@ -465,6 +473,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.ContainerSpec:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. hhttps://kubernetes.io/docs/api-reference/v1.6/#container-v1-core
     properties:
       args:
         type: string
@@ -574,6 +584,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.VolumeMount:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. hhttps://kubernetes.io/docs/api-reference/v1.6/#volumemount-v1-core
     properties:
       mountPath:
         type: string
@@ -582,6 +594,8 @@ data_types:
 
   org.alien4cloud.kubernetes.api.datatypes.ResourceRequirements:
     derived_from: tosca.datatypes.Root
+    description: >
+      c.f. hhttps://kubernetes.io/docs/api-reference/v1.6/#resourcerequirements-v1-core
     properties:
       limits:
         type: org.alien4cloud.kubernetes.api.datatypes.ResourceRequest

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -266,7 +266,7 @@ data_types:
         required: false
         description: |
           Label query over pods that should match the pod count. Normally, the system sets this field for you
-          
+
   org.alien4cloud.kubernetes.api.datatypes.PodTemplateSpec:
     derived_from: tosca.datatypes.Root
     description: >
@@ -1108,6 +1108,34 @@ node_types:
           - equal: Deployment
       spec:
         type: org.alien4cloud.kubernetes.api.datatypes.DeploymentSpec
+
+  org.alien4cloud.kubernetes.api.types.Job:
+    derived_from: org.alien4cloud.kubernetes.api.types.AbstractJob
+
+  org.alien4cloud.kubernetes.api.types.AbstractJob:
+    abstract: true
+    derived_from: org.alien4cloud.kubernetes.api.types.Base
+    description: >
+      Represent a kubernetes Job
+    capabilities:
+      host: tosca.capabilities.Container.Docker
+    properties:
+      apiVersion:
+        type: string
+        description: |
+          APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources
+        default: batch/v1
+        constraints:
+          - equal: batch/v1
+      kind:
+        type: string
+        description: |
+          Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+        default: Job
+        constraints:
+          - equal: Job
+      spec:
+        type: org.alien4cloud.kubernetes.api.datatypes.JobSpec
 
   org.alien4cloud.kubernetes.api.types.HorizontalPodAutoscaler:
     derived_from: org.alien4cloud.kubernetes.api.types.Base

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -178,8 +178,19 @@ data_types:
         constraints:
           valid_values: [ 'ExternalName', 'ClusterIP', 'NodePort', 'LoadBalancer' ]
 
-  org.alien4cloud.kubernetes.api.datatypes.DeploymentSpec:
+  org.alien4cloud.kubernetes.api.datatypes.ControllerSpec:
     derived_from: tosca.datatypes.Root
+    description: >
+      Used to provied template of PodTemplateSpec to controllers as Job, Deployment, and in the future, StatefulSet
+    properties:
+      template:
+        type: org.alien4cloud.kubernetes.api.datatypes.PodTemplateSpec
+        required: false
+        description: |
+          Template describes the pods that will be created.
+
+  org.alien4cloud.kubernetes.api.datatypes.DeploymentSpec:
+    derived_from: org.alien4cloud.kubernetes.api.datatypes.ControllerSpec
     description: >
       c.f. https://kubernetes.io/docs/api-reference/v1.6/#deploymentspec-v1beta1-apps
     properties:
@@ -223,11 +234,6 @@ data_types:
         required: false
         description: |
           The deployment strategy to use to replace existing pods with new ones.
-      template:
-        type: org.alien4cloud.kubernetes.api.datatypes.PodTemplateSpec
-        required: false
-        description: |
-          Template describes the pods that will be created.
 
   org.alien4cloud.kubernetes.api.datatypes.PodTemplateSpec:
     derived_from: tosca.datatypes.Root

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -2,12 +2,12 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.alien4cloud.kubernetes.api
-  template_version: 2.0.0
+  template_version: 2.1.0-SNAPSHOT
   # this version will be changed at build time (see maven-replacer-plugin in pom.xml)
   template_author: alien4cloud
 
 description: |
-  Kubernetes types that fit to K8S api, used by K8S topology modifiers and describe K8S matchable resources.
+  Kubernetes types that fit to K8S api, used by K8S topology modifiers and describe K8S matchable resources ; modified for Jobs support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20


### PR DESCRIPTION
This PR provides new TOSCA types to support the deployment of Kubernetes Jobs.
It also extends the Kubernetes topology modifiers in order to take into account these new TOSCA types and such allow Kubernetes Jobs to be run. 

These new types and extended modifiers were tested by deploying Docker containers to a Kubernetes cluster via the Yorc orchestrator.

In order to test them, you need to install and Alien4Cloud 2.1.0-SNAPSHOT and do the followings:

- replace the 5-docker-tosca-types.zip in init/archives by the one built from the https://github.com/alien4cloud/docker-tosca-types/tree/feature/jobs branch
- replace the alien4cloud-kubernetes-plugin-2.1.0-SNAPSHOT.zip by the one build from this branch
- add a yorc plugin built from the branch : https://github.com/ystia/yorc-a4c-plugin/tree/feature/k8s-job
Then you have to create a Yorc orchestrator and a Kubernetes location having the necessary On demand Resource types : org.alien4cloud.kubernetes.api.Job and org.alien4cloud.kubernetes.api.Container

Moreover, a  Yorc server built from branch https://github.com/ystia/yorc/tree/feature/k8s-job have to be installed and configured ; the configuration must allow Yorc to deploy TOSCA applications to a Kubernetes cluster. 
Note that we used a GKE framework, aka a Kubernetes cluter running on Google Cloud Platform.

The test applications were created using TOSCA types defined in : https://github.com/ystia/yorc-a4c-plugin/blob/feature/k8s-job/tosca-samples/org/ystia/yorc/samples/kube/jobs/types.yaml


