### PR TITLE
Add namespace property for job resources

### DIFF
--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -1714,6 +1714,11 @@ node_types:
     description: >
       Represent a Job kubernetes final resource after node matching
     properties:
+      namespace:
+        type: string
+        required: false
+        description: |
+          The namespace where the resource is deployed.
       resource_spec:
         type: string
         description: |


### PR DESCRIPTION
Add 'namespace' property to org.alien4cloud.kubernetes.api.types.BaseJobResource in order to support namespace specification for Jobs

Fix issue https://github.com/alien4cloud/alien4cloud-kubernetes-plugin/issues/5