### PR TITLE
Support Volumes For K8S Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ target
 /.idea/
 .tmp
 *.iml
+.vscode
+.settings
+.project
+.factorypath
+.classpath

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
@@ -389,6 +389,14 @@ public class KubernetesFinalTopologyModifier extends AbstractKubernetesModifier 
         NodeTemplate targetContainer = topology.getNodeTemplates().get(relationshipTemplate.get().getTarget());
         // find the deployment that hosts this container
         NodeTemplate deploymentContainer = TopologyNavigationUtil.getHostOfTypeInHostingHierarchy(topology, targetContainer, K8S_TYPES_DEPLOYMENT);
+        if (deploymentContainer == null) {
+            // find the job that hosts this container
+            deploymentContainer = TopologyNavigationUtil.getHostOfTypeInHostingHierarchy(topology, targetContainer, K8S_TYPES_JOB);
+        }
+        if (deploymentContainer == null) {
+            ctx.getLog().error("failed to get controller hosting volume <"+ volumeNode.getName() + ">");
+            return;
+        }
         // get the deployment resource corresponding to this deployment
         NodeTemplate deploymentResourceNode = nodeReplacementMap.get(deploymentContainer.getName());
 


### PR DESCRIPTION
## Description of the change

### What I did

First check if the container to mount the volume on is hosted on a Deployment, if not then check if it is hosted on a ContainerJobUnit. If this is still not the case then fail in error instead of producing a NPE

### How to verify it

Add a `ContainerJobUnit` then host on it a `DockerExtVolume` and a `ContainerRuntime`.
On the `ContainerRuntime` host a simple `DockerImage` for instance with bash.

Then map the `DockerExtVolume` to a `HostPathVolumeSource` and configure your image to list the content of this directory.

When running the Job the content of the directory should appear in logs.

## Applicable Issues

Fixes #8 