### PR TITLE
Support spec.selector now required on new versions

### DIFF
--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
@@ -947,6 +947,8 @@ public class KubernetesFinalTopologyModifier extends AbstractKubernetesModifier 
         String stsName = generateConsistentKubeName(statefulsetNode.getName());
         feedPropertyValue(statefulsetResourceNodeProperties, "resource_def.metadata.name", stsName, false);
         feedPropertyValue(statefulsetNode.getProperties(), "spec.template.metadata.labels.app", stsName, false);
+        log.info("Set spec.selector.matchLabels.app to "+stsName);
+        feedPropertyValue(statefulsetNode.getProperties(), "spec.selector.matchLabels.app", stsName, false);
         feedPropertyValue(statefulsetNode.getProperties(), "metadata.name", stsName, false);
         AbstractPropertyValue resource_id = PropertyUtil.getPropertyValueFromPath(safe(statefulsetNode.getProperties()), "metadata.name");
         if(resource_id == null){

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesFinalTopologyModifier.java
@@ -947,7 +947,6 @@ public class KubernetesFinalTopologyModifier extends AbstractKubernetesModifier 
         String stsName = generateConsistentKubeName(statefulsetNode.getName());
         feedPropertyValue(statefulsetResourceNodeProperties, "resource_def.metadata.name", stsName, false);
         feedPropertyValue(statefulsetNode.getProperties(), "spec.template.metadata.labels.app", stsName, false);
-        log.info("Set spec.selector.matchLabels.app to "+stsName);
         feedPropertyValue(statefulsetNode.getProperties(), "spec.selector.matchLabels.app", stsName, false);
         feedPropertyValue(statefulsetNode.getProperties(), "metadata.name", stsName, false);
         AbstractPropertyValue resource_id = PropertyUtil.getPropertyValueFromPath(safe(statefulsetNode.getProperties()), "metadata.name");

--- a/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesLocationTopologyModifier.java
+++ b/src/main/java/org/alien4cloud/plugin/kubernetes/modifier/KubernetesLocationTopologyModifier.java
@@ -8,6 +8,7 @@ import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.A4C_T
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.A4C_TYPES_CONTAINER_RUNTIME;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.A4C_TYPES_DOCKER_ARTIFACT_VOLUME;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.A4C_TYPES_DOCKER_VOLUME;
+import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.K8S_SERVICE_NAME_PROPERTY;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.K8S_TYPES_ABSTRACT_ARTIFACT_VOLUME_BASE;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.K8S_TYPES_ABSTRACT_CONTAINER;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.K8S_TYPES_ABSTRACT_CONTROLLER;
@@ -21,9 +22,7 @@ import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.gener
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.getContainerImageName;
 import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.getValue;
 import static org.alien4cloud.tosca.utils.ToscaTypeUtils.isOfType;
-import static org.alien4cloud.plugin.kubernetes.modifier.KubeTopologyUtils.K8S_SERVICE_NAME_PROPERTY;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -303,6 +302,7 @@ public class KubernetesLocationTopologyModifier extends AbstractKubernetesModifi
         ScalarPropertyValue deploymentName = new ScalarPropertyValue(generateUniqueKubeName(context, nodeTemplate.getName()));
         setNodePropertyPathValue(csar, topology, nodeTemplate, "metadata.name", deploymentName);
         setNodePropertyPathValue(csar, topology, nodeTemplate, "spec.template.metadata.labels.app", deploymentName);
+        setNodePropertyPathValue(csar, topology, nodeTemplate, "spec.selector.matchLabels.app", deploymentName);
     }
 
 
@@ -329,6 +329,7 @@ public class KubernetesLocationTopologyModifier extends AbstractKubernetesModifi
         ScalarPropertyValue deploymentName = new ScalarPropertyValue(generateUniqueKubeName(context, hostNode.getName()));
         setNodePropertyPathValue(csar, topology, hostNode, "metadata.name", deploymentName);
         setNodePropertyPathValue(csar, topology, hostNode, "spec.template.metadata.labels.app", deploymentName);
+        setNodePropertyPathValue(csar, topology, hostNode, "spec.selector.matchLabels.app", deploymentName);
         Set<NodeTemplate> hostedContainers = TopologyNavigationUtil.getSourceNodes(topology, nodeTemplate, "host");
         // we may have a single hosted container
         for (NodeTemplate containerNode : hostedContainers) {

--- a/src/main/resources/csar/tosca.yml
+++ b/src/main/resources/csar/tosca.yml
@@ -236,7 +236,7 @@ data_types:
         description: |
           Maximum number of revisions that will be maintained in the revision history. The revision history consists of all revisions not represented by a currently applied version.
       selector:
-        type: string # datetype: org.alien4cloud.kubernetes.api.datatypes.LabelSelector
+        type: org.alien4cloud.kubernetes.api.datatypes.LabelSelector
         required: false
         description: |
           Label query over pods that should match the pod count. Normally, the system sets this field for you


### PR DESCRIPTION
Support spec.selector now required on new versions for deployments & statefulsets

To be ported on 3.0